### PR TITLE
Fix for OAI-PMH schema compliance

### DIFF
--- a/LR/lr/lib/resumption_token.py
+++ b/LR/lr/lib/resumption_token.py
@@ -22,8 +22,7 @@ def parse_token(serviceid, token):
         
     return decoded
 
-
-def get_token(serviceid, startkey=None, endkey={}, startkey_docid=None, from_date=None, until_date=None):
+def get_payload(startkey=None, endkey={}, startkey_docid=None, from_date=None, until_date=None):
     payload = {}
 
     payload["startkey"] = startkey
@@ -37,11 +36,10 @@ def get_token(serviceid, startkey=None, endkey={}, startkey_docid=None, from_dat
         payload["from_date"] = h.convertToISO8601Zformat(from_date)
     if until_date and isinstance(until_date, datetime.datetime):
         payload["until_date"] = until_date
-        
-    return jwt.encode(payload, serviceid, __JWT_ALG)
-
-def get_offset_token(serviceid, offset=None, keys=None):
     
+    return payload
+
+def get_offset_payload(offset=None, keys=None):
     payload = {}
     
     if offset:
@@ -49,7 +47,13 @@ def get_offset_token(serviceid, offset=None, keys=None):
     if keys:
         payload["keys"] = keys
     
-    return jwt.encode(payload, serviceid, __JWT_ALG)
+    return payload
+
+def get_token(serviceid, startkey=None, endkey={}, startkey_docid=None, from_date=None, until_date=None):
+    return jwt.encode(get_payload(startkey, endkey, startkey_docid, from_date, until_date), serviceid, __JWT_ALG)
+
+def get_offset_token(serviceid, offset=None, keys=None):
+    return jwt.encode(get_offset_payload(offset, keys), serviceid, __JWT_ALG)
 
 
 if __name__ == "__main__":

--- a/LR/lr/mustache/oaipmh.py
+++ b/LR/lr/mustache/oaipmh.py
@@ -98,3 +98,19 @@ class Error(object):
                 opts[key] = getattr(err,key)
 
         return pystache.render(template, opts)
+    
+class ErrorOnly(object):
+    def xml(self, err=None):
+        template = '''<error code="{{code}}">{{msg}}</error>'''
+        opts = {
+                "response_date": None,
+                "verb": None,
+                "path_url": None,
+                "code": None,
+                "msg": None
+                }
+        for key in opts.keys():
+            if key in dir(err):
+                opts[key] = getattr(err,key)
+
+        return pystache.render(template, opts)

--- a/couchdb/resource_data/apps/oai-pmh-identify-timestamp/views/docs/map.js
+++ b/couchdb/resource_data/apps/oai-pmh-identify-timestamp/views/docs/map.js
@@ -1,5 +1,19 @@
 function(doc) {
 	if (doc.doc_type && doc.doc_type == "resource_data" && doc.node_timestamp) {
-		emit(doc.node_timestamp, 1);
+		if (doc.payload_placement && doc.payload_placement == "inline" && doc.resource_data) {
+			
+			try {
+				var e4x = new XML(doc.resource_data.replace(/^<\?xml\s+version\s*=\s*(["'])[^\1]+\1[^?]*\?>/, ""));
+				if (e4x) {
+					emit(doc.node_timestamp, 1);
+				}
+			} catch (error){
+				
+			}
+			
+		} else {
+			emit(doc.node_timestamp, 1);
+		}
+		
 	}
 }

--- a/couchdb/resource_data/apps/oai-pmh-list-identifiers/views/docs/map.js
+++ b/couchdb/resource_data/apps/oai-pmh-list-identifiers/views/docs/map.js
@@ -1,9 +1,28 @@
 function(doc) {
 
 	if (doc.doc_type && doc.doc_type=="resource_data" && doc.node_timestamp && doc.payload_schema) {
-		for (var i = 0; i < doc.payload_schema.length; i++) {
-			ts = doc.node_timestamp.replace(/\.[0-9]+Z/gi, "");
-			emit([doc.payload_schema[i],ts], null);
+		
+		var okay = false;
+		if (doc.payload_placement && doc.payload_placement == "inline" && doc.resource_data) {
+			
+			try {
+				var e4x = new XML(doc.resource_data.replace(/^<\?xml\s+version\s*=\s*(["'])[^\1]+\1[^?]*\?>/, ""));
+				if (e4x) {
+					okay = true;
+				}
+			} catch (error){
+				okay = false;
+			}
+			
+		} else {
+			okay = true;
+		}
+		
+		if (okay) {
+			for (var i = 0; i < doc.payload_schema.length; i++) {
+				ts = doc.node_timestamp.replace(/\.[0-9]+Z/gi, "");
+				emit([doc.payload_schema[i],ts], null);
+			}
 		}
 	}
 }

--- a/couchdb/resource_data/apps/oai-pmh-list-metadata-formats/views/docs/map.js
+++ b/couchdb/resource_data/apps/oai-pmh-list-metadata-formats/views/docs/map.js
@@ -1,14 +1,33 @@
 function(doc) {
 	if (doc.doc_type && doc.doc_type == "resource_data" && doc.payload_schema) {
-		for (var i = 0; i < doc.payload_schema.length; i++) {
+		
+		var okay = false;
+		if (doc.payload_placement && doc.payload_placement == "inline" && doc.resource_data) {
 			
-			if (doc.doc_ID) {
-				emit([doc.payload_schema[i], "by_doc_ID",doc.doc_ID], (doc.payload_schema_locator ? doc.payload_schema_locator : null));
-			}
-			if (doc.resource_locator) {
-				emit([doc.payload_schema[i], "by_resource_locator",doc.resource_locator], (doc.payload_schema_locator ? doc.payload_schema_locator : null));
+			try {
+				var e4x = new XML(doc.resource_data.replace(/^<\?xml\s+version\s*=\s*(["'])[^\1]+\1[^?]*\?>/, ""));
+				if (e4x) {
+					okay = true;
+				}
+			} catch (error) {
+				okay = false;
 			}
 			
+		} else {
+			okay = true;
+		}
+		
+		if (okay) {
+			for (var i = 0; i < doc.payload_schema.length; i++) {
+				
+				if (doc.doc_ID) {
+					emit([doc.payload_schema[i], "by_doc_ID",doc.doc_ID], (doc.payload_schema_locator ? doc.payload_schema_locator : null));
+				}
+				if (doc.resource_locator) {
+					emit([doc.payload_schema[i], "by_resource_locator",doc.resource_locator], (doc.payload_schema_locator ? doc.payload_schema_locator : null));
+				}
+				
+			}
 		}
 	}
 }


### PR DESCRIPTION
This pull _should_ fix any problems left for issues #29 & #14.  The DC 1.1 data has vanished from the system.  It was observed that OAI-PMH GetRecord, ListRecords, and ListIdentifiers would return XML escaped metadata for non XML formats. This modification does 2 things:
1. Updates the CouchDB views to 'check' any any inline payloads in the OAI-PMH views to validate that they contain XML using E4X. This will reduce the index size substantially, and exclude any docs that wouldn't be returned by virtue of not containing any XML payload.
2. Removes any XML escaping that was being done, and instead checks the payload for valid XML formatting. If it fails, the document is excluded from the result.

There's 1 minor fix that was included with the commit, which fixes a problem where id_limit in service_data was being used for both ListIdentifiers and ListRecords.

Post pull, deployment will require:
1. Push all couch views; I'd suggest running compaction post push and initiate a index.  The couch_utils.py in config will push all the apps by default to the specified db.
2. The read timeout in NGINX needs to be increased, I'm guessing 1 hour is good, this is to **try** and prevent an edge case where a schema format is requested, but large numbers of payloads are invalid (which cannot be checked until requested):
          For FastCGI: fastcgi_read_timeout 3600;
          For uwsgi: uwsgi_read_timeout 3600;

This commit has also been added to LearningRegistry/master

Signed-off-by: Jim Klo jim.klo@sri.com
