### PR TITLE
Fix for #108

### DIFF
--- a/LR/lr/lib/oaipmh.py
+++ b/LR/lr/lib/oaipmh.py
@@ -74,7 +74,7 @@ class OAIPMHDocumentResolver(CouchDBDocProcessor):
  
             try:
                 doc["resource_data"] = re.sub('''^<\?xml\s+version\s*=\s*(["][^"]+["]|['][^']+['])[^?]*\?>''', "", doc["resource_data"])
-                doc["resource_data"] = re.sub('''\s*<!DOCTYPE\s[^>]*>''', "", doc["resource_data"], flags=re.MULTILINE)
+#                doc["resource_data"] = re.sub('''\s*<!DOCTYPE\s[^>]*>''', "", doc["resource_data"], flags=re.MULTILINE)
                 payload = etree.parse(StringIO(doc["resource_data"]))
                 doc["resource_data"] = etree.tostring(payload)
             except:


### PR DESCRIPTION
Commented out line which was an untested partial solution for #37. Existing line uses syntax that is incompatible with Python 2.6.x on the LR servers.

Signed-off-by: Jim Klo jim.klo@sri.com
