### PR TITLE
Fixed bug where service_type is missing

### DIFF
--- a/config/services/Basic_Harvest.py
+++ b/config/services/Basic_Harvest.py
@@ -64,6 +64,7 @@ class __BasicHarvestServiceTemplate(ServiceTemplate):
             "service_endpoint": "/harvest",
             "service_key": "false", 
             "service_https": "false",
+            "service_type":"access",
             "spec_kv_only": None,
             "flow_control": False,
             "id_limit": False,

--- a/config/services/Basic_Obtain.py
+++ b/config/services/Basic_Obtain.py
@@ -57,6 +57,7 @@ class __BasicObtainServiceTemplate(ServiceTemplate):
             "service_endpoint": "/obtain",
             "service_key": "false", 
             "service_https": "false",
+            "service_type":"access",
             "spec_kv_only": False,
             "flow_control": False,
             "id_limit": None,

--- a/config/services/Basic_Publish.py
+++ b/config/services/Basic_Publish.py
@@ -54,6 +54,7 @@ class __BasicPublishServiceTemplate(ServiceTemplate):
             "service_name": "Basic Publish",
             "service_version": "0.23.0",
             "service_endpoint": "/publish",
+            "service_type":"publish",
             "service_key": "false", 
             "service_https": "false",
             "doc_limit": None ,

--- a/config/services/OAI-PMH_Harvest.py
+++ b/config/services/OAI-PMH_Harvest.py
@@ -59,6 +59,7 @@ class __OaiServiceTemplate(ServiceTemplate):
             "service_endpoint": "/OAI-PMH",
             "service_key": "false", 
             "service_https": "false",
+            "service_type":"access",
             "spec_kv_only": None,
             "flow_control": "false",
             "id_limit": None,

--- a/config/services/Slice.py
+++ b/config/services/Slice.py
@@ -55,6 +55,7 @@ class __SliceServiceTemplate(ServiceTemplate):
             "service_endpoint": "/slice",
             "service_key": "false", 
             "service_https": "false",
+            "service_type":"access",
             "flow_control": False,
             "id_limit": None,
             "doc_limit": None,


### PR DESCRIPTION
Fixes the bug where the service_type is missing from all service descriptions installed with the plugins
