### PR TITLE
at some point the distribute_threshold_handler.py lost is reference to json

### DIFF
--- a/LR/lr/model/resource_data_monitor/distribute_threshold_handler.py
+++ b/LR/lr/model/resource_data_monitor/distribute_threshold_handler.py
@@ -12,7 +12,7 @@ import urllib2
 from lr.lib.couch_change_monitor import BaseChangeThresholdHandler
 from pylons import config
 import logging
-
+import json
 appConfig = config['app_conf']
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
distribute_threshold_handler.py lost it's reference to json and this caused the call to distribute to not work.
