### PR TITLE
eliminated some redundant keys in the Slice index

### DIFF
--- a/couchdb/resource_data/apps/learningregistry-slice/views/docs/map.js
+++ b/couchdb/resource_data/apps/learningregistry-slice/views/docs/map.js
@@ -13,14 +13,38 @@ function(doc) {
 		return false;
 	}	
 	
+	
 	//grab all the identities in identity or submitter/curator/owner/signer (depending on version)
+	//if any identities are identical, ignore redundant ones.
 	if(doc.identity) {
-		if(doc.identity.submitter) identities.push(doc.identity.submitter.toLowerCase());
-		if(doc.identity.curator) identities.push(doc.identity.curator.toLowerCase());
-		if(doc.identity.owner) identities.push(doc.identity.owner.toLowerCase());
-		if(doc.identity.signer) identities.push(doc.identity.signer.toLowerCase());
+		if(doc.identity.submitter) {
+			identities.push(doc.identity.submitter.toLowerCase());
+		}
+		if(doc.identity.curator) {
+			var curator = doc.identity.curator.toLowerCase();
+			if(!arrayContains(identities,curator)) {
+				identities.push(curator);
+			}
+		}
+		if(doc.identity.owner) {
+			var owner = doc.identity.owner.toLowerCase();
+			if(!arrayContains(identities,owner)) {
+				identities.push(owner);
+			}
+		}
+		if(doc.identity.signer) {
+			var signer = doc.identity.signer.toLowerCase();
+			if(!arrayContains(identities,signer)) {
+				identities.push(signer);
+			}
+		}
 	}
-	if(doc.submitter) identities.push(doc.submitter.toLowerCase());
+	if(doc.submitter) {
+		var submitter = doc.submitter.toLowerCase();
+		if(!arrayContains(identities,submitter)) {
+			identities.push(submitter);
+		}
+	} 
 	
 
 	//build identities indices


### PR DESCRIPTION
A slight modification of map that will not map redundant keys for cases
when the same entity is entered for multiple identities. (e.g. "SRI" is
both submitter and signer.)
