### PR TITLE
removed hardcoded service document name and pull from ini file

### DIFF
--- a/LR/lr/controllers/slice.py
+++ b/LR/lr/controllers/slice.py
@@ -34,7 +34,7 @@ class SliceController(BaseController):
         self.fc_id_limit = None
         self.fc_doc_limit = None
         
-        self.serviceDoc = h.getServiceDocument("access:slice")
+        self.serviceDoc = h.getServiceDocument(appConfig['lr.slice.docid'])
         if self.serviceDoc != None:
             if 'service_id' in self.serviceDoc:
                 self.service_id = self.serviceDoc['service_id']


### PR DESCRIPTION
slice had a hard coded service document name, changed to pull from the config file.  This was causing flow control to not work on production as slice was looking for access:slice and the correct name is access:Slice Service
