### PR TITLE
fix an issue with bad none type being returned for replication

### DIFF
--- a/LR/LR.egg-info/PKG-INFO
+++ b/LR/LR.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 1.0
 Name: LR
-Version: 0.1dev
+Version: 0.23.10dev
 Summary: UNKNOWN
 Home-page: UNKNOWN
 Author: UNKNOWN

--- a/LR/lr/lib/helpers.py
+++ b/LR/lr/lib/helpers.py
@@ -28,6 +28,8 @@ def getBasicAuthHeaderFromURL(basic_auth_url):
         if "username" in urlparts and "password" in urlparts and urlparts.username != None and urlparts.password != None:
             base64_enc = base64.encodestring("%s:%s" % (urlparts.username, urlparts.password)).replace("\n", "")
             return { "Authorization": "Basic %s" % base64_enc }
+        else:
+            return { }
     except:
         return { }
         

--- a/LR/setup.py
+++ b/LR/setup.py
@@ -7,7 +7,7 @@ except ImportError:
 
 setup(
     name='LR',
-    version='0.23.9',
+    version='0.23.10',
     description='',
     author='',
     author_email='',


### PR DESCRIPTION
Found this issue when assisting KY setup a distribution network... If there's no credentials it was passing None back instead of an empty object.

This fixes that.
