### PR TITLE
Fix CORS support when publishing using Authentication header

### DIFF
--- a/LR/lr/lib/base.py
+++ b/LR/lr/lib/base.py
@@ -18,7 +18,7 @@ class BaseController(WSGIController):
     def options(self):        
     	response.headers['Access-Control-Allow-Methods'] = 'GET, POST, OPTIONS'
     	response.headers['Access-Control-Max-Age'] = '1728000'
-        response.headers['Access-Control-Allow-Headers'] = 'Content-Type,Origin,Accept'
+        response.headers['Access-Control-Allow-Headers'] = 'Content-Type,Origin,Accept,Authorization'
     def setOrigin(self):
         if 'origin' in request.headers:
            response.headers['Access-Control-Allow-Origin'] = request.headers['origin']


### PR DESCRIPTION
CORS support for OPTIONS request wasn't returning 'Authorization' in the value list for the `Access-Control-Allow-Headers` header.

This just adds Authorization to the list of values returned in the 'Access-Control-Allow-Headers' header response from an OPTIONS request.

Signed-off-by: Jim Klo jim.klo@sri.com
