### PR TITLE
Update setup.py

### DIFF
--- a/LR/setup.py
+++ b/LR/setup.py
@@ -13,7 +13,7 @@ setup(
     author_email='',
     url='http://www.learningregistry.org',
     install_requires=[
-        "WebOb==1.1.1", "nose==1.2.0", "Pylons==1.0", "pyparsing==1.5.5", "restkit==3.2.3",
+        "WebOb==1.2.3", "nose==1.2.0", "Pylons==1.0", "pyparsing==1.5.5", "restkit==3.2.3",
         "couchdb==0.8", "lxml==2.3", "iso8601plus==0.1.5", "ijson==0.8.0", "WebTest==1.1",
         "pystache==0.3.1", "PyJWT==0.1.4", "Couchapp==0.8.1", "PyBrowserID>=0.5.0",
         "LRSignature==0.1.13", "python-gnupg>=0.3.0", "oauth2==1.5.211", "jsonschema==0.8.0",


### PR DESCRIPTION
During compilation, install stops requiring WebOb 1.2.3.  Updated reference to 1.2.3.
