### PR TITLE
Bug in the config/service_util.py script that causes node signing error.

### DIFF
--- a/config/service_util.py
+++ b/config/service_util.py
@@ -95,7 +95,7 @@ lr_start () {
     fi
 
     echo "Starting LR Node. Log: $LR_LOG   PID: $LR_PID"
-    su $LR_USER -c "{{#LR_VIRTUALENV}}source $LR_VIRTUALENV/bin/activate; {{/LR_VIRTUALENV}}uwsgi --ini-paste $LR_HOME/development.ini {{#LR_VIRTUALENV}}-H $LR_VIRTUALENV{{/LR_VIRTUALENV}} --pidfile $LR_PID --daemonize $LR_LOG{{#LR_VIRTUALENV}}; deactivate{{/LR_VIRTUALENV}}"
+    su $LR_USER -c "cd $LR_HOME;{{#LR_VIRTUALENV}}source $LR_VIRTUALENV/bin/activate; {{/LR_VIRTUALENV}}uwsgi --ini-paste $LR_HOME/development.ini {{#LR_VIRTUALENV}}-H $LR_VIRTUALENV{{/LR_VIRTUALENV}} --pidfile $LR_PID --daemonize $LR_LOG{{#LR_VIRTUALENV}}; deactivate{{/LR_VIRTUALENV}}"
 }
 
 lr_stop () {
@@ -115,7 +115,7 @@ lr_restart () {
         echo "Restarting LR Node. Log: $LR_LOG   PID: $LR_PID"
         su $LR_USER -c "{{#LR_VIRTUALENV}}source $LR_VIRTUALENV/bin/activate; {{/LR_VIRTUALENV}}uwsgi --stop $LR_PID{{#LR_VIRTUALENV}}; deactivate{{/LR_VIRTUALENV}}"
         su $LR_USER -c "rm -f $LR_PID"
-        su $LR_USER -c "{{#LR_VIRTUALENV}}source $LR_VIRTUALENV/bin/activate; {{/LR_VIRTUALENV}}uwsgi --ini-paste $LR_HOME/development.ini {{#LR_VIRTUALENV}}-H $LR_VIRTUALENV{{/LR_VIRTUALENV}} --pidfile $LR_PID --daemonize $LR_LOG{{#LR_VIRTUALENV}}; deactivate{{/LR_VIRTUALENV}}"
+        su $LR_USER -c "cd $LR_HOME;{{#LR_VIRTUALENV}}source $LR_VIRTUALENV/bin/activate; {{/LR_VIRTUALENV}}uwsgi --ini-paste $LR_HOME/development.ini {{#LR_VIRTUALENV}}-H $LR_VIRTUALENV{{/LR_VIRTUALENV}} --pidfile $LR_PID --daemonize $LR_LOG{{#LR_VIRTUALENV}}; deactivate{{/LR_VIRTUALENV}}"
     else
         echo "LR Node not running.  Please use [start]"
     fi


### PR DESCRIPTION
When setting up a couple of new nodes, discovered that the config/service_util.py creates an init.d script that doesn't use the right working directory.

Modified the start / restart functions to ``cd $LR_HOME;`` first, and then perform the rest of the command. 