### PR TITLE
Fix service_util for new uwsgi and a typo in docs

### DIFF
--- a/config/service_util.py
+++ b/config/service_util.py
@@ -95,7 +95,7 @@ lr_start () {
     fi
 
     echo "Starting LR Node. Log: $LR_LOG   PID: $LR_PID"
-    su $LR_USER -c "{{#LR_VIRTUALENV}}source $LR_VIRTUALENV/bin/activate;{{/LR_VIRTUALENV}} cd $LR_HOME; uwsgi --ini-paste $LR_HOME/development.ini {{#LR_VIRTUALENV}}-H $LR_VIRTUALENV{{/LR_VIRTUALENV}} --pidfile $LR_PID --daemonize $LR_LOG{{#LR_VIRTUALENV}}; deactivate{{/LR_VIRTUALENV}}"
+    su $LR_USER -c "{{#LR_VIRTUALENV}}source $LR_VIRTUALENV/bin/activate;{{/LR_VIRTUALENV}} cd $LR_HOME; uwsgi --enable-threads --no-orphans --ini-paste $LR_HOME/development.ini {{#LR_VIRTUALENV}}-H $LR_VIRTUALENV{{/LR_VIRTUALENV}} --pidfile $LR_PID --daemonize $LR_LOG{{#LR_VIRTUALENV}}; deactivate{{/LR_VIRTUALENV}}"
 }
 
 lr_stop () {
@@ -115,7 +115,7 @@ lr_restart () {
         echo "Restarting LR Node. Log: $LR_LOG   PID: $LR_PID"
         su $LR_USER -c "{{#LR_VIRTUALENV}}source $LR_VIRTUALENV/bin/activate; {{/LR_VIRTUALENV}}uwsgi --stop $LR_PID{{#LR_VIRTUALENV}}; deactivate{{/LR_VIRTUALENV}}"
         su $LR_USER -c "rm -f $LR_PID"
-        su $LR_USER -c "{{#LR_VIRTUALENV}}source $LR_VIRTUALENV/bin/activate; {{/LR_VIRTUALENV}} cd $LR_HOME; uwsgi --ini-paste $LR_HOME/development.ini {{#LR_VIRTUALENV}}-H $LR_VIRTUALENV{{/LR_VIRTUALENV}} --pidfile $LR_PID --daemonize $LR_LOG{{#LR_VIRTUALENV}}; deactivate{{/LR_VIRTUALENV}}"
+        su $LR_USER -c "{{#LR_VIRTUALENV}}source $LR_VIRTUALENV/bin/activate; {{/LR_VIRTUALENV}} cd $LR_HOME; uwsgi --enable-threads --no-orphans --ini-paste $LR_HOME/development.ini {{#LR_VIRTUALENV}}-H $LR_VIRTUALENV{{/LR_VIRTUALENV}} --pidfile $LR_PID --daemonize $LR_LOG{{#LR_VIRTUALENV}}; deactivate{{/LR_VIRTUALENV}}"
     else
         echo "LR Node not running.  Please use [start]"
     fi

--- a/docs/spec/General_Matter/index.rst
+++ b/docs/spec/General_Matter/index.rst
@@ -395,22 +395,26 @@ Change Log
 
 *NB*: See the :doc:`Learning <../Technical_Spec/index>` :doc:`Registry <../Technical_Spec/index>` :doc:`Technical <../Technical_Spec/index>` :doc:`Specification <../Technical_Spec/index>` for prior change history not listed below.
 
-+-------------+----------+------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| **Version** | **Date** | **Author** | **Change**                                                                                                                                                                                                            |
-+-------------+----------+------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-|             | 20110921 | DR         | This document extracted from the monolithic V 0.24.0 document. `Archived copy (V 0.24.0) <https://docs.google.com/document/d/1Yi9QEBztGRzLrFNmFiphfIa5EF9pbV5B6i9Tk4XQEXs/edit?hl=en_US>`_                            |
-+-------------+----------+------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| 0.50.0      | 20110926 | DR         | Editorial updates to create stand alone version. Changed license from OWA CLA 0.9 to OWA CLA 1.0. Added section on versioning. Archived copy location TBD. (V GM:0.50.0)                                              |
-+-------------+----------+------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Future      | TBD      |            | XXXArchived copy location TBD. (V GM:x.xx.x)                                                                                                                                                                          |
-+-------------+----------+------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| 0.50.1      | 20130312 | JK         | Converted spec source format to RestructuredText. `Archive copy (V GM:0.50.0) <https://docs.google.com/document/d/1B5DqiN2YhjPZ5qApWGvWVyeuOjFpIOHiRlF9kjgPjzU/edit>`_                                                |
-+-------------+----------+------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| 0.51.0      | 20140219 | jH         | Updated version number and shading of changes only. Updates to the spec are in the :doc:`Resource Data Data Model <../Resource_Data_Data_Model/index>`.
-                                        `Archive copy (V GM:0.50.0) <http://docs.learningregistry.org/en/0.50.1/spec/General_Matter/index.html>`                                                                                                              |
-+-------------+----------+------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
++-------------+----------+------------+----------------------------------------------------------------------------------------------------+
+| **Version** | **Date** | **Author** | **Change**                                                                                         |
++=============+==========+============+====================================================================================================+
+|             | 20110921 | DR         | This document extracted from the monolithic V 0.24.0 document. `Archived copy (V 0.24.0)           |
+|             |          |            | <https://docs.google.com/document/d/1Yi9QEBztGRzLrFNmFiphfIa5EF9pbV5B6i9Tk4XQEXs/edit?hl=en_US>`_  |
++-------------+----------+------------+----------------------------------------------------------------------------------------------------+
+| 0.50.0      | 20110926 | DR         | Editorial updates to create stand alone version. Changed license from OWA CLA 0.9 to OWA CLA 1.0.  |
+|             |          |            | Added section on versioning. Archived copy location TBD. (V GM:0.50.0)                             |
++-------------+----------+------------+----------------------------------------------------------------------------------------------------+
+| Future      | TBD      |            | XXXArchived copy location TBD. (V GM:x.xx.x)                                                       |
++-------------+----------+------------+----------------------------------------------------------------------------------------------------+
+| 0.50.1      | 20130312 | JK         | Converted spec source format to RestructuredText. `Archive copy (V GM:0.50.0)                      |
+|             |          |            | <https://docs.google.com/document/d/1B5DqiN2YhjPZ5qApWGvWVyeuOjFpIOHiRlF9kjgPjzU/edit>`_           |
++-------------+----------+------------+----------------------------------------------------------------------------------------------------+
+| 0.51.0      | 20140219 | jH         | Updated version number and shading of changes only. Updates to the spec are in the :doc:`Resource  |
+|             |          |            | Data Data Model <../Resource_Data_Data_Model/index>`. `Archive copy (V GM:0.50.0)                  |
+|             |          |            | <http://docs.learningregistry.org/en/0.50.1/spec/General_Matter/index.html>`                       |
++-------------+----------+------------+----------------------------------------------------------------------------------------------------+
 
-
+ 
 
 
 

--- a/etc/init.d/learningregistry
+++ b/etc/init.d/learningregistry
@@ -34,7 +34,7 @@ lr_start () {
         exit 1
     fi
     cd $LR_HOME
-    su $LR_USER -c "source $LR_VIRTUALENV/bin/activate; uwsgi --ini-paste $LR_HOME/development.ini start -H $LR_VIRTUALENV --pidfile $LR_PID --daemonize $LR_LOG --master -p $LR_PROC_COUNT;deactivate"
+    su $LR_USER -c "source $LR_VIRTUALENV/bin/activate; uwsgi --enable-threads --no-orphans --ini-paste $LR_HOME/development.ini start -H $LR_VIRTUALENV --pidfile $LR_PID --daemonize $LR_LOG --master -p $LR_PROC_COUNT;deactivate"
     echo "LR Node is starting. Log: $LR_LOG   PID: $LR_PID"
 }
 
@@ -52,7 +52,7 @@ lr_restart () {
     then
         cd $LR_HOME
         su $LR_USER -c "source $LR_VIRTUALENV/bin/activate;uwsgi --stop $LR_PID;rm -f $LR_PID"
-        su $LR_USER -c "source $LR_VIRTUALENV/bin/activate; uwsgi --ini-paste $LR_HOME/development.ini start -H $LR_VIRTUALENV --pidfile $LR_PID --daemonize $LR_LOG --master -p $LR_PROC_COUNT;deactivate"
+        su $LR_USER -c "source $LR_VIRTUALENV/bin/activate; uwsgi --enable-threads --no-orphans --ini-paste $LR_HOME/development.ini start -H $LR_VIRTUALENV --pidfile $LR_PID --daemonize $LR_LOG --master -p $LR_PROC_COUNT;deactivate"
         echo "LR Node is restarting. Log: $LR_LOG   PID: $LR_PID"
     fi
 


### PR DESCRIPTION
Two things:

1. Current[1] uwsgi needs two additional options in order for the jobs to work correctly with LR monitor threads, as well as with the start/stop script.

2. There was a typo in a table within one of the docs.  I fixed it so the documentation will regenerate without errors.