### PR TITLE
v0.51.0 bug fixes

### DIFF
--- a/LR/plugins/admin_signed_tombstone.py
+++ b/LR/plugins/admin_signed_tombstone.py
@@ -1,7 +1,7 @@
 from lr.plugins import ITombstonePolicy, DoNotPublishError
 from pylons import config
 from pprint import pprint
-from os import walk
+from os import walk, path
 from lr.lib.signing import gpg
 
 import logging, copy
@@ -23,7 +23,7 @@ class AdminSignedTombstone(ITombstonePolicy):
         for (dirpath, dirnames, filenames) in walk(public_key_directory):
             for f in filenames:
                 if f[-4:] == '.txt':
-                    with open(dirpath+f, 'r') as key_file:
+                    with open(os.path.join(dirpath,f), 'r') as key_file:
                         self.public_key_fingerprints.extend(gpg.import_keys(key_file.read()).fingerprints)
                         print "Loading key from %s%s" % (dirpath, f)
 

--- a/LR/plugins/admin_signed_tombstone.py
+++ b/LR/plugins/admin_signed_tombstone.py
@@ -23,7 +23,7 @@ class AdminSignedTombstone(ITombstonePolicy):
         for (dirpath, dirnames, filenames) in walk(public_key_directory):
             for f in filenames:
                 if f[-4:] == '.txt':
-                    with open(os.path.join(dirpath,f), 'r') as key_file:
+                    with open(path.join(dirpath,f), 'r') as key_file:
                         self.public_key_fingerprints.extend(gpg.import_keys(key_file.read()).fingerprints)
                         print "Loading key from %s%s" % (dirpath, f)
 

--- a/config/setup_node.py
+++ b/config/setup_node.py
@@ -244,6 +244,9 @@ if __name__ == "__main__":
                     )
     parser.add_option("-r", "--response", dest="response_file", default=None,
                       help="Specify a filename for writing a response_file to input.")
+
+    parser.add_option("--show", dest="show_pass", action="store_true", default=False,
+                      help="Echo passwords - needed when using response files.")
     (options, args) = parser.parse_args()
     print("\n\n=========================\nNode Configuration\n")
     if options.devel:
@@ -255,6 +258,9 @@ if __name__ == "__main__":
         response_file.set(options.response_file)
 
     nodeSetup = getSetupInfo()
+
+    nodeSetup["show_pass"] = options.show_pass
+
     print("\n\n=========================\nNode Configuration\n")
     for k in nodeSetup.keys():
         print("{0}:  {1}".format(k, nodeSetup[k]))

--- a/config/setup_utils.py
+++ b/config/setup_utils.py
@@ -311,7 +311,7 @@ def setNodeSigning(server, config, setupInfo):
         config.set("app:main","lr.publish.signing.signer",signer)
 
 
-        passphrase = getInput("Passphrase for Signing with Private Key [typing is concealed]", "", checkPassphrase(gpg, privateKeyId), hide_input=setupInfo["show_pass"])
+        passphrase = getInput("Passphrase for Signing with Private Key [typing is concealed]", "", checkPassphrase(gpg, privateKeyId), hide_input=!setupInfo["show_pass"])
         setupInfo["lr.publish.signing.passphrase"] = passphrase
         config.set("app:main","lr.publish.signing.passphrase",passphrase)
 

--- a/config/setup_utils.py
+++ b/config/setup_utils.py
@@ -311,7 +311,7 @@ def setNodeSigning(server, config, setupInfo):
         config.set("app:main","lr.publish.signing.signer",signer)
 
 
-        show_pass = !setupInfo["show_pass"]
+        show_pass = not setupInfo["show_pass"]
         passphrase = getInput("Passphrase for Signing with Private Key [typing is concealed]", "", checkPassphrase(gpg, privateKeyId), hide_input=show_pass)
         setupInfo["lr.publish.signing.passphrase"] = passphrase
         config.set("app:main","lr.publish.signing.passphrase",passphrase)

--- a/config/setup_utils.py
+++ b/config/setup_utils.py
@@ -311,7 +311,8 @@ def setNodeSigning(server, config, setupInfo):
         config.set("app:main","lr.publish.signing.signer",signer)
 
 
-        passphrase = getInput("Passphrase for Signing with Private Key [typing is concealed]", "", checkPassphrase(gpg, privateKeyId), hide_input=!setupInfo["show_pass"])
+        show_pass = !setupInfo["show_pass"]
+        passphrase = getInput("Passphrase for Signing with Private Key [typing is concealed]", "", checkPassphrase(gpg, privateKeyId), hide_input=show_pass)
         setupInfo["lr.publish.signing.passphrase"] = passphrase
         config.set("app:main","lr.publish.signing.passphrase",passphrase)
 

--- a/config/setup_utils.py
+++ b/config/setup_utils.py
@@ -311,7 +311,7 @@ def setNodeSigning(server, config, setupInfo):
         config.set("app:main","lr.publish.signing.signer",signer)
 
 
-        passphrase = getInput("Passphrase for Signing with Private Key [typing is concealed]", "", checkPassphrase(gpg, privateKeyId), hide_input=True)
+        passphrase = getInput("Passphrase for Signing with Private Key [typing is concealed]", "", checkPassphrase(gpg, privateKeyId), hide_input=setupInfo["show_pass"])
         setupInfo["lr.publish.signing.passphrase"] = passphrase
         config.set("app:main","lr.publish.signing.passphrase",passphrase)
 

--- a/docs/start/distribute.rst
+++ b/docs/start/distribute.rst
@@ -1,0 +1,80 @@
+************************************
+Learning Registry Distribution Guide
+************************************
+
+
+Configure a LR Node for Distribution
+====================================
+
+* When setting up a node, answer ``T`` for the question, ``Is the node "open"?``
+  
+* To run the distribution service for your node on-demand, hit the URL directly *locally* on the node:
+	
+	.. code-block:: bash
+	
+	    curl -XPOST -H "Content-Type:application/json" http://localhost/distribute
+
+* To automate the service add a cron job to the root user on the node. On the LR public nodes it runs hourly with the following in the root user’s crontab:
+
+	.. code-block:: bash
+	
+	    @hourly curl -XPOST -H "Content-Type:application/json" http://localhost/distribute
+
+* Other node admins register to have your node distribute to them at ``http://<yourNodesPublicAddress>/register`` 
+
+    - Mozilla Persona account required.
+
+* Registered connections are viewable in the ``node`` couchdb database. To disable a registered connection, set the active key to false, or just delete the document describing the connection.
+  
+* You must restart the LR Service to apply any changes that were made to the distribution policy. This includes:
+
+	- Registering new nodes to the distribute list.
+	- Removing existing node from the distribute list, either via disabling or by deletion.
+	  
+
+Setting up a node as a destination for distribution
+===================================================
+
+* when setting up your node, answer ``T`` for the question: ``Does the node want to be the destination for replication (T/F)?``
+* Register for distribution on the source node: ``http://<sourceNodePublicAddress>/register``
+
+    - a Mozilla Persona account is required to verify your identity.
+    - Default destination URL on your node is ``http://yourNodesPublicAddress/incoming``
+
+        + this will be checked when you submit the form.
+        + Username and Password in the registration form are for the CouchDB admin account on your node
+
+            * This will not be checked when you submit the form.
+
+* Ask the node administrator to restart the LR service on their node to load the new distribute connection. Wait until the distribute service runs to see the replicated documents on your node.
+
+
+Outstanding Questions/Issues
+============================
+
+* Can/Should we remove the necessity to restart the LR service to apply changes to distribution connections? 
+  
+  	- Some historical reasoning on GitHub: https://github.com/LearningRegistry/LearningRegistry/issues/276 
+
+* How do documents go from incoming to the resource_data database? 
+  
+    - Issue report: https://github.com/LearningRegistry/LearningRegistry/issues/275
+    - There is an issue with uwsgi versions.  Newer versions need to have the LR startup script modified in order to support multi-threading. See the ``/etc/init.d/learningregistry`` script within the GitHub source for details.
+    
+
+* Distribute service returns an empty error when no connections to distribute to 
+
+	- Issue report: https://github.com/LearningRegistry/LearningRegistry/issues/274	
+
+* What is the distributeResourceDataUrl parameter used for? This is separate from the incoming destination URL (distributeIncomingUrl). In the setup script, the question is posed as… Enter distribute/replication resource_data destination URL (this is the resource_data URL that another node couchdb will use to replicate/distribute to this node).
+
+	- As Distribute relies heavily upon CouchDB to function, CouchDB needs to know the public endpoint of the node which can be read by the destiation node.  It's possible to configure the node such that resource_data and incoming CouchDB databases are made available via a different URL, hence the need to prompt for ``distributeResourceDataUrl`` and ``distributeIncomingUrl`` respectively.
+
+* Can you register and distribute to a node that has “Admin Party” enabled (no admin username or password)?
+
+    - Yes, but this is not recommended as anyone who can access the CouchDB will have full read/write/modify permissions to the incoming DB.
+    
+* What happens when the supported schema version numbers don’t match between source and destination? Will v0.51 documents be accepted by v0.49 nodes?
+
+    - v0.49 nodes will reject v0.51 documents.
+    - v0.51 nodes will accept all current and legacy documents verions, v0.51 and prior. 

--- a/docs/start/index.rst
+++ b/docs/start/index.rst
@@ -8,3 +8,4 @@ Contents:
    :maxdepth: 2
 
    Learning Registry 20 Minute Guide <20min>
+   Learning Registry Distribution Guide <distribute>


### PR DESCRIPTION
1. Fix a bug in Trusted Whitelist which could cause an issue if an incorrect path separator is specified in the config.
2. Add feature for configuration script to support recording and echoing of passwords for automating installs.
3. Add documentation for distribute with a mini-FAQ.