### PR TITLE
Add missing "resource_data_type" to "Deleting a Learning Registry Doc…

### DIFF
--- a/docs/start/20min.rst
+++ b/docs/start/20min.rst
@@ -547,7 +547,7 @@ Removal of documents from Learning Registry follows a similar process as describ
 
 The key differences are:
   * Set the ``"payload_placement": "none"`` 
-  * The ``"resource_locator"``. ``"payload_schema"``, ``"resource_data"``, and ``"recource_data_types"`` properties of the Learning Registry Document may be omitted.
+  * The ``"resource_locator"``. ``"payload_schema"``, ``"resource_data"`` properties of the Learning Registry Document may be omitted.
 
 An example of Learning Registry Delete Document is:
 
@@ -583,7 +583,7 @@ An example of Learning Registry Delete Document is:
         "submitter_type": "agent"
 
       },
-
+      "resource_data_type": "metadata",
       "payload_placement": "none"
 
     }


### PR DESCRIPTION
…ument" example

"resource_data_type" is a required property in delete requests, but it was missing in the example.

See https://github.com/LearningRegistry/LearningRegistry/issues/264#issuecomment-29768003
